### PR TITLE
Add NotifyClose handling to consumer and publisher channels

### DIFF
--- a/amqp.go
+++ b/amqp.go
@@ -400,6 +400,10 @@ func (c *Client) Listen() {
 		case err := <-c.errors:
 			Error.Printf("An error in the connection to the AMQP broker occurred:\n%s", err)
 			if c.Reconnect {
+				closeErr := c.connection.Close()
+				if closeErr != nil && closeErr != amqp.ErrClosed {
+					Error.Printf("An error closing the old connection occurred:\n%s", closeErr)
+				}
 				c, _ = NewClient(c.uri, c.Reconnect)
 				c.consumers = consumers
 				for _, cs := range c.consumers {

--- a/amqp.go
+++ b/amqp.go
@@ -403,15 +403,15 @@ func (c *Client) Listen() {
 				c, _ = NewClient(c.uri, c.Reconnect)
 				c.consumers = consumers
 				for _, cs := range c.consumers {
-					err := c.initconsumer(cs)
-					if err != nil {
-						Error.Printf("An error re-establishing an AMQP consumer occurred:\n%s", err)
+					cerr := c.initconsumer(cs)
+					if cerr != nil {
+						Error.Printf("An error re-establishing an AMQP consumer occurred:\n%s", cerr)
 					}
 				}
 				if c.publisher != nil {
-					err = c.SetupPublishing(c.publisher.exchange)
-					if err != nil {
-						Error.Printf("An error re-establishing AMQP publishing occurred:\n%s", err)
+					perr := c.SetupPublishing(c.publisher.exchange)
+					if perr != nil {
+						Error.Printf("An error re-establishing AMQP publishing occurred:\n%s", perr)
 					}
 				}
 			} else {


### PR DESCRIPTION
and, re-stablish publishing when reconnecting to AMQP

I think this can resolve some lingering and confusing bugs in some of our Go AMQP services. We've been getting "channel/connection is not open" errors (the amqp library's `ErrClosed`), but everything we were doing was set with the reconnect flag on. However, it appears that we were subscribing to `NotifyClose` (provided by streadway/amqp) for the `Connection` but not for any `Channel`s. Some channels this is appropriate -- we open a new channel to purge a queue or ensure one exists, for example, and we wouldn't want to rebuild the connection from the ground up when that closes, since it's expected to do exactly that. However, we have long-lived channels that we expect to continue working in two places: consumers, and the lone publisher that can optionally be associated with a client.

This PR subscribes those channels' NotifyClose to the same error channel that the connection is, which when the reconnection is enabled is already configured to tear down and rebuild the client. That rebuilding didn't account for if there was a publisher set on the client, so I added that. The reconnection logic is also in `client.Listen`, which may mean that this doesn't help things if a given client connects and _only_ publishes messages. I haven't dug in to see if that's the case anywhere (though I think it is), because I thought it was valuable to at least get this part up and available to review.

I haven't yet tested this with any of our services. Will probably try to do that soon, but basically, don't count on it having successfully run in any real-ish conditions when reviewing, haha.